### PR TITLE
Feature/spiral search

### DIFF
--- a/source/control/compact-combinator-surface.lua
+++ b/source/control/compact-combinator-surface.lua
@@ -15,25 +15,43 @@ local private = {} -- private methods
 
 
 -- returns the coordinates of a new chunk to be used for a compact-combinator
-function Surface.newSpot(x, y)
+function Surface.newSpot(pos_x, pos_y)
 	local data = private.data()
 	
-	local c = { math.floor(x/32), math.floor(y/32) }
-	if not private.isChunkUsed(c) then
-		private.markChunk(c, true)
-		return c
-	end
-	
-	for x=-1,1 do for y=-1,1 do
-		if math.abs(x)+math.abs(y) == 1 then
-			local c2 = {c[1]+x, c[2]+y}
-			if not private.isChunkUsed(c2) then
-				private.markChunk(c2, true)
-				return c2
+	-- spiral search
+	local x = math.floor(pos_x / 32)
+	local y = math.floor(pos_y / 32)
+	local radius = 1
+	local direction = 1
+
+	while true do
+		-- move Y up/down
+		for dy = 0,radius do
+			local chunk = {x, y}
+			if not private.isChunkUsed(chunk) then
+				private.markChunk(chunk, true)
+				return chunk
 			end
+			y = y + direction
 		end
-	end end
-	return nil -- could not find a free chunk nearby
+		-- move X right/left
+		for dx = 0,radius  do
+			local chunk = {x, y}
+			if not private.isChunkUsed(chunk) then
+				private.markChunk(chunk, true)
+				return chunk
+			end
+			x = x + direction
+		end
+		direction = -direction
+		radius = radius + 1
+
+		-- abort if first 9 tiles have no match (remove once infinite distances are allowed)
+		if radius > 2 then
+			return nil
+		end
+	end
+
 end
 
 

--- a/source/control/compact-combinator-surface.lua
+++ b/source/control/compact-combinator-surface.lua
@@ -33,6 +33,13 @@ function Surface.newSpot(pos_x, pos_y)
 				return chunk
 			end
 			y = y + direction
+
+			-- START OF LIMITING CODE (remove when no longer needed)
+			if radius = 3 and dy = 2 then
+				return nil
+			end
+			-- END OF LIMITING CODE
+
 		end
 		-- move X right/left
 		for dx = 0,radius  do
@@ -46,10 +53,11 @@ function Surface.newSpot(pos_x, pos_y)
 		direction = -direction
 		radius = radius + 1
 
-		-- abort if first 9 tiles have no match (remove once infinite distances are allowed)
-		if radius > 2 then
+		-- limit to a search square of approx. 50 x 50 (=2500) chunks
+		if radius > 50 then
 			return nil
 		end
+
 	end
 
 end


### PR DESCRIPTION
Implements a spiral based search for finding free chunks

While the spiral search is in principle infinitely scalable, it is currently limited to a search grid of around 50x50 chunks (= approx. 2500 chunks total)

Additionally for now the spiral search aborts after the first 9 chunks. this is done so that for now (until #12 is fully implemented) we never find chunks that are too far away. This "early abort" is clearly marked and can simply be removed later.

The algorithm used has been verified in Java for up to 50x50 chunks. The following graph shows the square-spiral pattern generated from the sequence of generated coordinates:
<img width="959" alt="Screenshot 2020-02-11 at 18 36 46" src="https://user-images.githubusercontent.com/5485109/74263397-03a8ff80-4cff-11ea-866f-fee460fa1e97.png">
